### PR TITLE
Added link to drive in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # VizInt
 Visual intelligence : machines and minds cs-503 project 
+
+# Google Drive 
+
+https://drive.google.com/drive/folders/1LHqYKbK7mnTss1dMJ5pxNwz88EKoSwS6?usp=sharing
+
+contains corruption detector models and the training dataset for corruption detection
+


### PR DESCRIPTION
The readme now contains the link to a google drive so people can access the dataset used to train the corruption detection model and the model itself.

The model seems to struggle to detects guaussian
blurr probably because the pipeline normalize the
input in one of the first layer